### PR TITLE
`yaml.load` without `Loader` is deprecated and fails on newer Python versions

### DIFF
--- a/graphsaint/utils.py
+++ b/graphsaint/utils.py
@@ -109,7 +109,7 @@ def parse_layer_yml(arch_gcn,dim_input):
 
 def parse_n_prepare(flags):
     with open(flags.train_config) as f_train_config:
-        train_config = yaml.load(f_train_config)
+        train_config = yaml.safe_load(f_train_config)
     arch_gcn = {
         'dim': -1,
         'aggr': 'concat',


### PR DESCRIPTION
Changing `yaml.load` to `yaml.safe_load` since the first call is deprecated now (https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation) and fails with the following error:

```python
TypeError: load() missing 1 required positional argument: 'Loader'
```